### PR TITLE
User defined locals in manhole shell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,8 @@ Options
 
     manhole.install(
         verbose=True, patch_fork=True, activate_on=None, oneshot_on=None,
-        sigmask=manhole.ALL_SIGNALS, socket_path=None, reinstall_bind_delay=0.5)
+        sigmask=manhole.ALL_SIGNALS, socket_path=None, reinstall_bind_delay=0.5,
+        locals=None)
 
 * ``verbose`` - set it to ``False`` to squelch the stderr ouput
 * ``patch_fork`` - set it to ``False`` if you don't want your ``os.fork`` and ``os.forkpy`` monkeypatched
@@ -105,6 +106,7 @@ Options
   ``patch_fork`` as children cannot resuse the same path.
 * ``reinstall_bind_delay`` - Delay the unix domain socket creation *reinstall_bind_delay* seconds. This alleviates
   cleanup failures when using fork+exec patterns.
+* ``locals`` - names to add to manhole interactive shell locals.
 
 What happens when you actually connect to the socket
 ----------------------------------------------------


### PR DESCRIPTION
Typically, when you add a manhole to existing application, the
application was not designed for this, so finding stuff from the manhole
shell is hard or even impossible.

This patch adds a new locals optional argument, allowing a user to add
application specific objects to manhole shell locals.

Example usage:

```
manhole.install(locals={'server', my_server})
```

From the manhole shell, you can now use "server":

```
>>> server.status()
```

Installed locals are not inherited by child processes, since they may be
invalid in the child process.

Issue: #16
