### PR TITLE
Do not modify anything during fork+exec flow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Options
   doesn't.
 * ``socket_path`` - Use a specifc path for the unix domain socket (instead of ``/tmp/manhole-<pid>``). This disables
   ``patch_fork`` as children cannot resuse the same path.
-* ``reinstall_bind_delay`` - Delay the unix domain socket creation *reinstall_bind_delay* seconds. This alleviates
+* ``reinstall_delay`` - Delay the manhole reinstallation after fork *reinstall_delay* seconds. This alleviates
   cleanup failures when using fork+exec patterns.
 
 What happens when you actually connect to the socket


### PR DESCRIPTION
Recently a reinstall_bind_delay was added to avoid binding of unix
socket during fork+exec flow. However the socket is not the only issue
in this flow. Changing process signal mask should not be done, as such
changes may be inherited by the new process. Generally, since we don't
know yet if the manhole is needed, we should do nothing.

This patch changes the semantics of the reinstall_bind_delay so we do
not make any modification to child process (except starting a thread)
until the delay is finished.

The user visible parameter was shortened to "reinstall_delay", as the
user should not be conceded with the internals of the manhole.
Internally the Manhole class call it "setup_delay", as this is the
delay before setting up the manhole.
