### PR TITLE
Fix leftover /tmp/manhole-pid sockets in the tests

### DIFF
--- a/tests/test_manhole.py
+++ b/tests/test_manhole.py
@@ -26,6 +26,17 @@ TIMEOUT = int(os.getenv('MANHOLE_TEST_TIMEOUT', 10))
 SOCKET_PATH = '/tmp/manhole-socket'
 
 
+def handle_sigterm(signo, frame):
+    # Simulate real termination
+    print("Terminated")
+    sys.exit(128 + signo)
+
+
+# Handling sigterm ensure that atexit functions are called, and we do not leave
+# leftover /tmp/manhole-pid sockets.
+signal.signal(signal.SIGTERM, handle_sigterm)
+
+
 def is_module_available(mod):
     try:
         return imp.find_module(mod)


### PR DESCRIPTION
manhole.install() registers an exit function removing the manhole
socket, but atexit function do not run when process is terminated by an
unhandled signal.

In the fork tests, we avoid this issue by terminating child processes
with SIGINT, however the test child processes, created by the
process_tests library, are terminate using SIGTERM in
`TestProcess.__exit__`.

Adding SIGTERM signal handler fixed this issue.

We probably need to document this as a workaround for issue #8
