### PR TITLE
Fix hyperlink syntax in the changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog
 1.0.0 (2014-08-30)
 ------------------
 
-* Add ``socket_path`` install option (contributed by `Nir Soffer <https://github.com/nirs>`_).
+* Add ``socket_path`` install option (contributed by `Nir Soffer`_).
 * Add ``reinstall_bind_delay`` install option.
-* Add ``locals`` install option (contributed by `Nir Soffer <https://github.com/nirs>`_).
+* Add ``locals`` install option (contributed by `Nir Soffer`_).
 
 0.6.2 (2014-04-28)
 ------------------
@@ -17,4 +17,8 @@ Changelog
 0.6.1 (2014-04-28)
 ------------------
 
-* Support for OS X (contributed by `Saulius Menkevičius <https://github.com/razzmatazz>`_).
+* Support for OS X (contributed by `Saulius Menkevičius`_).
+
+.. _Saulius Menkevičius: https://github.com/razzmatazz
+.. _Nir Soffer: https://github.com/nirs
+


### PR DESCRIPTION
Commit 9578b3bd5ca introduced this error in the "check" target:

```
warning: check: Duplicate explicit target name: "nir soffer".
```
