### PR TITLE
Rename reinstall_bind_delay to reinstall_delay

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 ------------------
 
 * Added ``socket_path`` install option (contributed by `Nir Soffer`_).
-* Added ``reinstall_bind_delay`` install option.
+* Added ``reinstall_delay`` install option.
 * Added ``locals`` install option (contributed by `Nir Soffer`_).
 * Added ``redirect_stderr`` install option (contributed by `Nir Soffer`_).
 * Lots of internals cleanup (contributed by `Nir Soffer`_).

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Options
 
     manhole.install(
         verbose=True, patch_fork=True, activate_on=None, oneshot_on=None,
-        sigmask=manhole.ALL_SIGNALS, socket_path=None, reinstall_bind_delay=0.5,
+        sigmask=manhole.ALL_SIGNALS, socket_path=None, reinstall_delay=0.5,
         locals=None)
 
 * ``verbose`` - set it to ``False`` to squelch the stderr ouput
@@ -104,7 +104,7 @@ Options
   doesn't.
 * ``socket_path`` - Use a specifc path for the unix domain socket (instead of ``/tmp/manhole-<pid>``). This disables
   ``patch_fork`` as children cannot resuse the same path.
-* ``reinstall_bind_delay`` - Delay the unix domain socket creation *reinstall_bind_delay* seconds. This alleviates
+* ``reinstall_delay`` - Delay the unix domain socket creation *reinstall_delay* seconds. This alleviates
   cleanup failures when using fork+exec patterns.
 * ``locals`` - Names to add to manhole interactive shell locals.
 * ``daemon_connection`` - The connection thread is daemonic (dies on app exit). Default: ``False``.

--- a/src/manhole.py
+++ b/src/manhole.py
@@ -348,7 +348,7 @@ def _manhole_uds_name():
 _INST_LOCK = _ORIGINAL_ALLOCATE_LOCK()
 _STDERR = _INST = _ORIGINAL_OS_FORK = _ORIGINAL_OS_FORKPTY = _SHOULD_RESTART = None
 _SOCKET_PATH = None
-_REINSTALL_BIND_DELAY = None
+_REINSTALL_DELAY = None
 _REDIRECT_STDERR = True
 
 
@@ -390,7 +390,7 @@ ALL_SIGNALS = [
 
 
 def install(verbose=True, patch_fork=True, activate_on=None, sigmask=ALL_SIGNALS, oneshot_on=None, start_timeout=0.5,
-            socket_path=None, reinstall_bind_delay=0.5, locals=None, daemon_connection=False, redirect_stderr=True):
+            socket_path=None, reinstall_delay=0.5, locals=None, daemon_connection=False, redirect_stderr=True):
     """
     Installs the manhole.
 
@@ -409,18 +409,18 @@ def install(verbose=True, patch_fork=True, activate_on=None, sigmask=ALL_SIGNALS
             Python will force all the signal handling to be run in the main thread but signalfd doesn't.
         socket_path (str): Use a specifc path for the unix domain socket (instead of ``/tmp/manhole-<pid>``). This
             disables ``patch_fork`` as children cannot resuse the same path.
-        reinstall_bind_delay (float): Delay the unix domain socket creation *reinstall_bind_delay* seconds. This
+        reinstall_delay (float): Delay the unix domain socket creation *reinstall_delay* seconds. This
             alleviates cleanup failures when using fork+exec patterns.
         locals (dict): Names to add to manhole interactive shell locals.
         daemon_connection (bool): The connection thread is daemonic (dies on app exit). Default: ``False``.
         redirect_stderr (bool): Redirect output from stderr to manhole console. Default: ``True``.
     """
     global _STDERR, _INST, _SHOULD_RESTART  # pylint: disable=W0603
-    global VERBOSE, _REINSTALL_BIND_DELAY, _SOCKET_PATH, _REDIRECT_STDERR  # pylint: disable=W0603
+    global VERBOSE, _REINSTALL_DELAY, _SOCKET_PATH, _REDIRECT_STDERR  # pylint: disable=W0603
     with _INST_LOCK:
         VERBOSE = verbose
         _SOCKET_PATH = socket_path
-        _REINSTALL_BIND_DELAY = reinstall_bind_delay
+        _REINSTALL_DELAY = reinstall_delay
         _REDIRECT_STDERR = redirect_stderr
         _STDERR = sys.__stderr__
         if not _INST:
@@ -460,7 +460,7 @@ def reinstall():
     assert _INST
     with _INST_LOCK:
         if not (_INST.is_alive() and _INST in _ORIGINAL__ACTIVE):
-            _INST = _INST.clone(bind_delay=_REINSTALL_BIND_DELAY)
+            _INST = _INST.clone(bind_delay=_REINSTALL_DELAY)
             if _SHOULD_RESTART:
                 _INST.start()
 


### PR DESCRIPTION
"reinstall_bind_delay" describes correctly the underlying implementation,
but the manhole api should not expose implementation details.  From the
user point of view, this the delay before a new manhole is reinstalled
in a child process after fork, therefore the name is "reinstall_delay".
