### PR TITLE
Fix failures with pypy on slow or overloaded build machines

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         elif test_name == 'test_fork_exec':
             import subprocess
             manhole.install()
-            for i in range(500):
+            for i in range(50):
                 p = subprocess.Popen(['true'])
                 p.wait()
                 path = '/tmp/manhole-%d' % p.pid


### PR DESCRIPTION
We used to do 500 iterations in the fork_exec test, which is not really
needed. With no reinstall_delay, we need only 10-20 iterations to expose
this issue, so running 50 iterations is just fine.
