### PR TITLE
Ensure that manhole.install() invoked only once

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -83,6 +83,14 @@ if __name__ == '__main__':
             manhole.install(activate_on='USR2')
             for i in range(TIMEOUT * 100):
                 time.sleep(0.1)
+        elif test_name == 'test_install_once':
+            manhole.install()
+            try:
+                manhole.install()
+            except manhole.AlreadyInstalled:
+                print('ALREADY_INSTALLED')
+            else:
+                raise AssertionError("Did not raise AlreadyInstalled")
         elif test_name == 'test_fork_exec':
             manhole.install(reinstall_delay=5)
             print("Installed.")

--- a/tests/test_manhole.py
+++ b/tests/test_manhole.py
@@ -67,6 +67,13 @@ def test_simple():
                 proc.reset()
                 assert_manhole_running(proc, uds_path)
 
+
+def test_install_once():
+    with TestProcess(sys.executable, HELPER, 'test_install_once') as proc:
+        with dump_on_error(proc.read):
+            wait_for_strings(proc.read, TIMEOUT, 'ALREADY_INSTALLED')
+
+
 @mark.skipif(is_module_available('eventlet'), reason="evenlet can't deal with extra threads at process exit")
 def test_daemon_connection():
     with TestProcess(sys.executable, HELPER, 'test_daemon_connection') as proc:


### PR DESCRIPTION
Previously manhole.install() could be invoked multiple times leading to
multiple fork patching and hiding errors in user code.

Now only the first call would install the manhole, and the next attempt
will raise manhole.AlreadyInstalled exception, revealing bad user code.

This change also simplify the code, removing unneeded if block in the
normal code path.
