### PR TITLE
Make deadlock test faster and more correct

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -92,19 +92,17 @@ if __name__ == '__main__':
             else:
                 raise AssertionError("Did not raise AlreadyInstalled")
         elif test_name == 'test_stderr_doesnt_deadlock':
-            import subprocess
-            manhole.install()
-
-            for i in range(50):
-                print('running iteration', i)
-                p = subprocess.Popen(['true'])
-                print('waiting for process', p.pid)
-                p.wait()
-                print('process ended')
-                path = '/tmp/manhole-%d' % p.pid
-                if os.path.exists(path):
-                    os.unlink(path)
-                    raise AssertionError(path + ' exists !')
+            for _ in range(50):
+                pid = os.fork()
+                if pid:
+                    os.waitpid(pid, 0)
+                else:
+                    manhole.install()
+                    pid = os.fork()
+                    if pid:
+                        os.waitpid(pid, 0)
+                    else:
+                        sys.exit(0)
             print('SUCCESS')
         elif test_name == 'test_fork_exec':
             manhole.install(reinstall_delay=5)

--- a/tests/test_manhole.py
+++ b/tests/test_manhole.py
@@ -477,7 +477,6 @@ def test_sigmask():
 
 
 def test_stderr_doesnt_deadlock():
-    for _ in range(100):
-        with TestProcess(sys.executable, HELPER, 'test_stderr_doesnt_deadlock') as proc:
-            with dump_on_error(proc.read):
-                wait_for_strings(proc.read, TIMEOUT, 'SUCCESS')
+    with TestProcess(sys.executable, HELPER, 'test_stderr_doesnt_deadlock') as proc:
+        with dump_on_error(proc.read):
+            wait_for_strings(proc.read, TIMEOUT, 'SUCCESS')


### PR DESCRIPTION
The stderr deadlock was happening when manhole thread is crying to
stderr in the same time that the user call os.fork. This deadlock is
very easy to reproduce on Python 3 and pypy.

The test is testing now exactly this case:

```
manhole.install()
pid = os.fork()
```

To make the test faster, the loop moved into the helper, since the
testing infrastructure is not efficient enough, taking more than 200
milliseconds to run and wait for a process.

This change decrease the time from 26 seconds to about 1.3 second on my
laptop when using Python 2.7.
