### PR TITLE
Do not require Python 3.4 for check target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ commands =
     python bootstrap.py
 
 [testenv:check]
-basepython = python3.4
+basepython = python3
 deps =
     docutils
     check-manifest


### PR DESCRIPTION
Requiring Python 3.4 means that developers cannot run "tox -e check"
locally, since Python 3.4 may not be available. For example, on Fedora
20 we have Python 3.3.
