### PR TITLE
Cleanup _get_original

### DIFF
--- a/src/manhole.py
+++ b/src/manhole.py
@@ -33,34 +33,28 @@ else:
     setinterval = sys.setcheckinterval
     getinterval = sys.getcheckinterval
 
-
-def _get_original(qual_name):
-    mod, name = qual_name.split('.')
-    original = getattr(__import__(mod), name)
-
-    try:
-        from gevent.monkey import get_original
-        original = get_original(mod, name)
-    except (ImportError, SyntaxError):
-        pass
-
-    try:
-        from eventlet.patcher import original
-        original = getattr(original(mod), name)
-    except (ImportError, SyntaxError):
-        pass
-
-    return original
-_ORIGINAL_SOCKET = _get_original('socket.socket')
-_ORIGINAL_FDOPEN = _get_original('os.fdopen')
 try:
-    _ORIGINAL_ALLOCATE_LOCK = _get_original('thread.allocate_lock')
+    from eventlet.patcher import original as _original
+
+    def _get_original(mod, name):
+        return getattr(_original(mod), name)
+except ImportError:
+    try:
+        from gevent.monkey import get_original as _get_original
+    except ImportError:
+        def _get_original(mod, name):
+            return getattr(__import__(mod), name)
+
+_ORIGINAL_SOCKET = _get_original('socket', 'socket')
+_ORIGINAL_FDOPEN = _get_original('os', 'fdopen')
+try:
+    _ORIGINAL_ALLOCATE_LOCK = _get_original('thread', 'allocate_lock')
 except ImportError:  # python 3
-    _ORIGINAL_ALLOCATE_LOCK = _get_original('_thread.allocate_lock')
-_ORIGINAL_THREAD = _get_original('threading.Thread')
-_ORIGINAL_EVENT = _get_original('threading.Event')
-_ORIGINAL__ACTIVE = _get_original('threading._active')
-_ORIGINAL_SLEEP = _get_original('time.sleep')
+    _ORIGINAL_ALLOCATE_LOCK = _get_original('_thread', 'allocate_lock')
+_ORIGINAL_THREAD = _get_original('threading', 'Thread')
+_ORIGINAL_EVENT = _get_original('threading', 'Event')
+_ORIGINAL__ACTIVE = _get_original('threading', '_active')
+_ORIGINAL_SLEEP = _get_original('time', 'sleep')
 
 PY3 = sys.version_info[0] == 3
 PY26 = sys.version_info[:2] == (2, 6)
@@ -108,7 +102,7 @@ _VERBOSE = True
 _VERBOSE_DESTINATION = None
 
 
-def _cry(message, time=_get_original('time.time')):
+def _cry(message, time=_get_original('time', 'time')):
     """
     Fail-ignorant logging function.
     """


### PR DESCRIPTION
The previous code had few issues:
- We try to import possibly non-exiting modules on each call, which is
  expensive, looking up the the module in the entire import path. This
  is also pointless since the module is not expected to appear after we
  found that it was not available.
- Do pointless lookups, becuase older lookups overwrite previous
  lookups. For example, if gevent is available, we would lookup twice,
  overwriting the pure Python lookup with gevent lookup. If both gevent
  and eventlet are available, we would do 3 lookups and return the
  eventlet lookup.
- Check for SynatxError on import looks wrong. I could not find the
  code that raise this in the gevent and evetlet.
- _get_original interface was strage, accepting a string, instead of
  the expected module and name arguemtns, as used by
  gevent.monkey.get_original.

Now we use simpler and more efficient solution:
- We try to import eventlet or gevent only once
- We define _get_original either using eventlet, gevent or our
  implementaion.
- We do only single lookup per call
- _get_original accpets module and name arguments
