### PR TITLE
Remove unneeded poll flags

### DIFF
--- a/src/manhole/cli.py
+++ b/src/manhole/cli.py
@@ -81,8 +81,8 @@ class ConnectionHandler(threading.Thread):
 
     def run(self):
         if self.read_fd is not None:
-            self._poller.register(self.read_fd, select.POLLIN | select.POLLPRI | select.POLLERR | select.POLLHUP)
-        self._poller.register(self.conn_fd, select.POLLIN | select.POLLPRI | select.POLLERR | select.POLLHUP)
+            self._poller.register(self.read_fd, select.POLLIN)
+        self._poller.register(self.conn_fd, select.POLLIN)
 
         while self.should_run:
             self.poll()


### PR DESCRIPTION
According to poll(2) POLLERR and POLLHUP are are meaningless in the
events field, and will be set in the revents field whenever the
corresponding condition is true. So there is no need to register for
these events.

POLLPRI means there is urgent data to read. This can be read using the
MSG_OOB flag, but manhole-cli does not use this feature, so there is no
need to wait for this event.