### PR TITLE
Remove last exception's references if any

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ Authors
 * Nir Soffer - http://nirs.freeshell.org
 * Jesús Cea - https://github.com/jcea
 * "honnix" - https://github.com/honnix
+* Anton Ryzhov - https://github.com/anton-ryzhov

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+dev
+------------------
+
+* Fixed memory leak via ``sys.last_type``, ``sys.last_value``, ``sys.last_traceback``
+
 1.6.0 (2019-01-19)
 ------------------
 

--- a/src/manhole/__init__.py
+++ b/src/manhole/__init__.py
@@ -367,7 +367,14 @@ def handle_repl(locals):
     }
     if locals:
         namespace.update(locals)
-    ManholeConsole(namespace).interact()
+    try:
+        ManholeConsole(namespace).interact()
+    finally:
+        for attribute in ['last_type', 'last_value', 'last_traceback']:
+            try:
+                delattr(sys, attribute)
+            except AttributeError:
+                pass
 
 
 class Logger(object):


### PR DESCRIPTION
`code` module used underneath [stores](https://github.com/python/cpython/blob/f00e82f8b87c96ff76d6f768fa7a29cbd86eec6a/Lib/code.py#L139) exception details in [sys module](https://docs.python.org/3.6/library/sys.html#sys.last_type).

That creates a memory leak in case of exception in `manhole` session. This exception encapsulates entire session with all stack frames with their _locals_ and manhole internals (such as `ManholeConsole` instance and connection [file wrapper](https://github.com/ionelmc/python-manhole/pull/58)).

Simple test. Call this via manhole and target process will be 100Mb bigger even after disconnect:
```python
>>> padding = ' ' * 100 * 1024**2
>>> assert 0 
Traceback (most recent call last):
  File "<console>", line 1, in <module>
AssertionError
>>> ^D
now exiting ManholeConsole...
```